### PR TITLE
Enable NVDEC support in FFmpeg

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,6 +120,11 @@ parts:
       - desktop-qt5
       - ffmpeg
 
+  ffnvcodec:
+    plugin: make
+    source: https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+    source-branch: sdk/8.1
+
   ffmpeg:
     plugin: autotools
     source: https://git.ffmpeg.org/ffmpeg.git
@@ -131,17 +136,21 @@ parts:
       - --disable-static
       - --disable-all
       - --enable-avcodec
+      - --enable-nvdec
       - --enable-decoder=h264
       - --enable-decoder=hevc
       - --enable-hwaccel=h264_vaapi
       - --enable-hwaccel=hevc_vaapi
       - --enable-hwaccel=h264_vdpau
       - --enable-hwaccel=hevc_vdpau
+      - --enable-hwaccel=h264_nvdec
+      - --enable-hwaccel=hevc_nvdec
     build-packages:
       - libva-dev
       - libvdpau-dev
       - libx265-dev
       - nasm
+    after: [ffnvcodec]
 
   desktop-qt5:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git


### PR DESCRIPTION
Moonlight now supports using NVDEC decoding acceleration on NVIDIA GPUs if VDPAU is not available. This can be the case when running under XWayland or Wayland. By compiling it into our FFmpeg build, Moonlight will automatically pick it up if available.

One thing of note about the change: `source-branch: sdk/8.1` was chosen deliberately because each new branch of the headers removes support for older drivers. The Video Codec SDK 8.1 supports driver version 390.25 or newer.

To easily test NVDEC in the presence of working VDPAU support, you can use a bogus VDPAU_DRIVER value like: `VDPAU_DRIVER=foo moonlight`