### PR TITLE
Add __EGL_VENDOR_LIBRARY_DIRS for Mesa EGL

### DIFF
--- a/snap/local/va-wrapper
+++ b/snap/local/va-wrapper
@@ -17,6 +17,7 @@ VENDOR=$(glxinfo | grep "OpenGL vendor")
 
 export VDPAU_DRIVER_PATH="$SNAP/usr/lib/$ARCH/vdpau"
 export LIBVA_DRIVERS_PATH="$SNAP/usr/lib/$ARCH/dri"
+export __EGL_VENDOR_LIBRARY_DIRS="$__EGL_VENDOR_LIBRARY_DIRS:$SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d"
 
 if [[ $VENDOR == *"NVIDIA"* ]]; then
   export VDPAU_DRIVER_PATH="/var/lib/snapd/lib/gl/vdpau"


### PR DESCRIPTION
`__EGL_VENDOR_LIBRARY_DIRS` is not set correctly to pick up Mesa's libEGL.so. This prevents the Snap from starting on Wayland and blocks usage of the new EGL+GLES2 video renderer.

Reference for using `__EGL_VENDOR_LIBRARY_DIRS`: https://snapcraft.io/blog/building-a-rust-snap-by-example

I'm appending to `__EGL_VENDOR_LIBRARY_DIRS` rather than overwriting, because it may have [already been set](https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/common/desktop-exports#L103) for systems using the Nvidia proprietary GPU drivers with libglvnd.

Fixes #7 (with core20)